### PR TITLE
Added a score bonus for accurate chicken catching

### DIFF
--- a/World.pde
+++ b/World.pde
@@ -90,7 +90,7 @@ class World implements Scene {
       int timePenalty = round(-10 * timeSinceSaveStart);
       scores.put("Time Penalty", timePenalty);
       int accuracyBonus = max(0, ((amountOfChickensSaved+1) * 100) - (catchAttempts * 50));
-      score = round((amountOfChickensSaved * 500) - (timeSinceSaveStart * 10) + accuracyBonus);
+      scores.put("Accuracy Bonus", accuracyBonus);
       millisAtFoxDeath = millis();
 
       fox.state = FoxState.DEAD;

--- a/World.pde
+++ b/World.pde
@@ -30,8 +30,9 @@ class World implements Scene {
 
   ArrayList<Chicken> chickens;
 
-
   ArrayList<InWorldPopup> popups;
+
+  int catchAttempts = 0;
 
   World() {
     Width = displayWidth;
@@ -68,6 +69,7 @@ class World implements Scene {
 
   void attemptCatchChickenAt(PVector pos) {
     sfxNet.play();
+    catchAttempts++;
     for (int i = chickens.size()-1; i >= 0; i--) {
       Chicken c = chickens.get(i);
       if (pos.dist(c.pos) < 32) {
@@ -81,8 +83,10 @@ class World implements Scene {
 
   boolean attemptShootFoxAt(PVector pos) {
     sfxGun.play();
+    catchAttempts++;
     if (pos.dist(fox.pos) < 32) {
-      score = round(amountOfChickensSaved * 500 - timeSinceSaveStart * 10);
+      int accuracyBonus = max(0, ((amountOfChickensSaved+1) * 100) - (catchAttempts * 50));
+      score = round((amountOfChickensSaved * 500) - (timeSinceSaveStart * 10) + accuracyBonus);
       millisAtFoxDeath = millis();
 
       fox.state = FoxState.DEAD;


### PR DESCRIPTION
Closes #31

I'd like some feedback on the implementation.
As it currently works you get a score bonus of 100 per chicken caught(& fox killed), which is reduced by 50 for every catch attempt. So it's effectively a 50 score bonus per chicken.
For every additional catch attempt past that the bonus score is reduced by 50 more point, until it caps at 0 bonus score.